### PR TITLE
Fix AFD ffn_bs column: split into dense and MoE FFN batch sizes. Fix total_die range for heterogeneous throughput visualization

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -150,18 +150,26 @@ def main():
         "--max_die", str(args.max_die),
     ]
     # Add heterogeneous parameters if applicable
-    if args.deployment_mode == "Heterogeneous" and args.device_type2:
+    if args.deployment_mode == "Heterogeneous":
+        if args.device_type2 is None:
+                raise ValueError("device_type2 is required for Heterogeneous deployment mode")
         throughput_cmd.extend(["--device_type2", args.device_type2])
+        _min_die2 = args.min_die2 if args.min_die2 is not None else args.min_die
+        _max_die2 = args.max_die2 if args.max_die2 is not None else args.max_die
+        _die_step2 = args.die_step2 if args.die_step2 is not None else args.die_step
+        total_dies = list(range(args.min_die + _min_die2, args.max_die + _max_die2 + 1, min(args.die_step, _die_step2)))
+    else:
+        total_dies = list(range(args.min_die, args.max_die + 1, args.die_step))
     throughput_cmd.extend(["--micro_batch_num", "2", "3"])
     throughput_cmd.extend(["--tpot_list"] + [str(t) for t in args.tpot])
     throughput_cmd.extend(["--kv_len_list"] + [str(k) for k in args.kv_len])
-    throughput_cmd.extend(["--total_die"] + [str(t) for t in range(args.min_die, args.max_die + 1, args.die_step)])
+    throughput_cmd.extend(["--total_die"] + [str(t) for t in total_dies])
     subprocess.run(throughput_cmd)
 
     for tpot in args.tpot:
         for kv_len in args.kv_len:
             # Construct file name based on deployment mode
-            if args.deployment_mode == "Heterogeneous" and args.device_type2:
+            if args.deployment_mode == "Heterogeneous":
                 device_type2_enum = DeviceType(args.device_type2)
                 file_name = f"{DeviceType(args.device_type).name}_{device_type2_enum.name}-{ModelType(args.model_type).name}-tpot{tpot}-kv_len{kv_len}.csv"
             else:
@@ -171,7 +179,7 @@ def main():
                 "--file_name", file_name,
                 "--deployment_mode", args.deployment_mode,
             ]
-            if args.deployment_mode == "Heterogeneous" and args.device_type2:
+            if args.deployment_mode == "Heterogeneous":
                 pipeline_cmd.extend(["--device_type2", args.device_type2])
             subprocess.run(pipeline_cmd)
 

--- a/src/search/afd.py
+++ b/src/search/afd.py
@@ -69,6 +69,7 @@ class AfdSearch(BaseSearch):
         # Compute MoE layer timing
         self.config.attn_bs = attn_bs
         self.config.ffn_bs = attn_bs * self.config.model_config.num_experts_per_tok * attn_die / ffn_die
+        moe_ffn_bs = self.config.ffn_bs
         self.config.attn_die = attn_die
         self.config.ffn_die = ffn_die
         self.config.routed_expert_per_die = routed_expert_per_die
@@ -99,6 +100,7 @@ class AfdSearch(BaseSearch):
         if self.config.model_config.num_layers > self.config.model_config.num_moe_layers:
             self.config.attn_bs = attn_bs * self.config.micro_batch_num
             self.config.ffn_bs = self.config.attn_bs
+            dense_ffn_bs = self.config.ffn_bs
             model_dense = get_model(self.config)
             attn_dense = model_dense["attn"]
             mlp = model_dense["mlp"]
@@ -107,6 +109,7 @@ class AfdSearch(BaseSearch):
             e2e_time_per_dense_layer = attn_dense.e2e_time * SEC_2_US + mlp.e2e_time * SEC_2_US
             e2e_time = e2e_time + e2e_time_per_dense_layer * self.config.model_config.first_k_dense_replace
         else:
+            dense_ffn_bs = 0
             e2e_time_per_dense_layer = 0.0
 
         e2e_time = e2e_time / (1 + self.config.multi_token_ratio) * US_2_MS
@@ -125,7 +128,8 @@ class AfdSearch(BaseSearch):
         ffn_available_memory = ffn_memory_threshold - ffn_used_memory
 
         return {
-            'ffn_bs': self.config.ffn_bs,
+            'moe_ffn_bs': moe_ffn_bs,
+            'dense_ffn_bs': dense_ffn_bs,
             'attn_time': attn_time,
             'moe_time': moe_time,
             'dispatch_time': dispatch_time,
@@ -229,7 +233,7 @@ class AfdSearch(BaseSearch):
                 logging.info(f"-------AFD Search Result:-------")
                 logging.info(
                     f"deployment_mode: {self.config.deployment_mode}, "
-                    f"attn_bs: {attn_bs}, ffn_bs: {result['ffn_bs']}, "
+                    f"attn_bs: {attn_bs}, dense_ffn_bs: {result['dense_ffn_bs']}, moe_ffn_bs: {result['moe_ffn_bs']}, "
                     f"kv_len: {self.config.kv_len}, attn_die: {attn_die}, "
                     f"ffn_die: {ffn_die}, total_die: {total_die}, "
                     f"attn_time: {result['attn_time']:.2f}us, moe_time: {result['moe_time']:.2f}us, "
@@ -245,7 +249,7 @@ class AfdSearch(BaseSearch):
                 )
 
                 self.perf_afd_results.append([
-                    attn_bs, result['ffn_bs'], self.config.kv_len, attn_die, ffn_die, total_die,
+                    attn_bs, result['dense_ffn_bs'], result['moe_ffn_bs'], self.config.kv_len, attn_die, ffn_die, total_die,
                     result['attn_time'], result['moe_time'], result['a2e_send'], result['a2e_recv'],
                     result['dispatch_time'], result['combine_time'], result['e2a_recv'], result['commu_time'],
                     result['e2e_time'], result['e2e_time_per_dense_layer'], result['e2e_time_per_moe_layer'], throughput,
@@ -256,7 +260,8 @@ class AfdSearch(BaseSearch):
                 ])
 
         columns = [
-            'attn_bs', 'ffn_bs', 'kv_len', 'attn_die', 'ffn_die', 'total_die',
+            'attn_bs(per_micro_batch)', 'dense_ffn_bs', 'moe_ffn_bs(per_micro_batch)',
+            'kv_len', 'attn_die', 'ffn_die', 'total_die',
             'attn_time(us)', 'moe_time(us)', 'a2e_send(us)', 'a2e_recv(us)', 'dispatch_time(us)', 'combine_time(us)', 'e2a_recv(us)', 'commu_time(us)',
             'e2e_time(ms)', 'e2e_time_per_dense_layer(us)', 'e2e_time_per_moe_layer(us)', 'throughput(tokens/die/s)',
             'kv_size(GB)', 'attn_static_memory(GB)', 'mlp_static_memory(GB)', 'ffn_static_memory(GB)',


### PR DESCRIPTION
1.Fix AFD ffn_bs column: split into dense and MoE FFN batch sizes. 
The previous ffn_bs column was overwritten by the dense layer computation, causing the MoE ffn_bs to be lost. Now export both moe_ffn_bs and dense_ffn_bs values as separate CSV columns:
- attn_bs(per_micro_batch): renamed from attn_bs for clarity
- dense_ffn_bs: dense MLP batch size (attn_bs * mbn)
- moe_ffn_bs(per_micro_batch): MoE expert batch size (attn_bs * num_experts_per_tok * attn_die / ffn_die)

previous:
<img width="175" height="208" alt="image" src="https://github.com/user-attachments/assets/1d8f6894-d14b-4843-92e7-a61e479e63fa" />

now:
<img width="584" height="230" alt="image" src="https://github.com/user-attachments/assets/a4d39cdd-8119-44a6-8ced-d9c64f66b968" />

2.Fix total_die range for heterogeneous throughput visualization.
  In heterogeneous mode, total_die = die1 + die2, but the previous code only used device1's die range to generate total_die values for throughput charts. Now compute total_die range from (min_die1+min_die2) to (max_die1+max_die2) with step = min(die_step1, die_step2).