### PR TITLE
[Feat]Add KV Cache quantization switch

### DIFF
--- a/conf/config.py
+++ b/conf/config.py
@@ -39,7 +39,8 @@ class Config:
         device_type2: Optional[str] = None,
         min_die2: Optional[int] = None,
         max_die2: Optional[int] = None,
-        die_step2: Optional[int] = None
+        die_step2: Optional[int] = None,
+        kv_cache_quant: str = "bf16"
     ) -> None:
         """
         Initialize a Config object.
@@ -76,6 +77,12 @@ class Config:
         if deployment_mode not in valid_deployment_modes:
             raise ValueError(f"Invalid deployment_mode: {deployment_mode}. Must be one of {valid_deployment_modes}")
         self.deployment_mode = deployment_mode
+
+        # Validate kv_cache_quant
+        valid_kv_cache_quant = ("bf16", "int8")
+        if kv_cache_quant not in valid_kv_cache_quant:
+            raise ValueError(f"Invalid kv_cache_quant: {kv_cache_quant}. Must be one of {valid_kv_cache_quant}")
+        self.kv_cache_quant = kv_cache_quant
 
         model_type = ModelType(model_type)
         self.model_type = model_type

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -65,6 +65,9 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
                         help="Max FFN dies for Heterogeneous mode")
     parser.add_argument('--die_step2', type=int, default=None,
                         help="Die step for FFN in Heterogeneous mode")
+    parser.add_argument('--kv_cache_quant', type=str, default="bf16",
+                        choices=["bf16", "int8"],
+                        help="KV cache quantization type: bf16 (default) or int8")
 
 
 def run_search(args):
@@ -97,7 +100,8 @@ def run_search(args):
                         device_type2=args.device_type2,
                         min_die2=args.min_die2,
                         max_die2=args.max_die2,
-                        die_step2=args.die_step2
+                        die_step2=args.die_step2,
+                        kv_cache_quant=args.kv_cache_quant
                     )
                     afd_search = AfdSearch(config)
                     afd_search.deployment()
@@ -124,7 +128,8 @@ def run_search(args):
                     device_type2=args.device_type2,
                     min_die2=args.min_die2,
                     max_die2=args.max_die2,
-                    die_step2=args.die_step2
+                    die_step2=args.die_step2,
+                    kv_cache_quant=args.kv_cache_quant
                 )
                 deepep_search = DeepEpSearch(config)
                 deepep_search.deployment()

--- a/src/model/deepseekv2_lite_decode.py
+++ b/src/model/deepseekv2_lite_decode.py
@@ -2,7 +2,7 @@ from conf.common import MAX_AVG_RATIO
 from conf.config import Config
 from src.model.base import BaseModule
 from src.ops import (
-    OpMlaProlog, MLAFlashAttentionInt8, OpTransposeBatchMatmul, OpBatchMatmul,
+    OpMlaProlog, MLAFlashAttention, OpTransposeBatchMatmul, OpBatchMatmul,
     OpQuantBatchMatmul, OpSwiglu, OpGroupedMatmul, Dispatch, Combine,
     OpAddRmsNorm, OpDynamicQuant, OpA2ESend, OpA2ERecv, OpE2ARecv
 )
@@ -38,7 +38,7 @@ class DeepSeekV2LiteDecodeAttn(BaseModule):
 
         self.input_norm = OpAddRmsNorm("input_norm", self.attn_bs, self.config.seq_len, hidden, self.aichip_config)
         self.mla_prolog = OpMlaProlog(self.config)
-        self.page_attention = MLAFlashAttentionInt8(self.config)
+        self.page_attention = MLAFlashAttention(self.config)
         self.bmm_uv_absorb = OpTransposeBatchMatmul("bmm_uv_absorb", heads, bs, self.model_config.kv_lora_rank, self.model_config.v_head_dim, self.aichip_config)
         self.dynamic_quant = OpDynamicQuant("dynamic_quant", bs, v_dim, self.aichip_config)
         self.bmm_o_proj = OpQuantBatchMatmul("bmm_o_proj", bs, v_dim, hidden, self.aichip_config)

--- a/src/model/deepseekv3_decode.py
+++ b/src/model/deepseekv3_decode.py
@@ -2,7 +2,7 @@ from conf.common import MAX_AVG_RATIO
 from conf.config import Config
 from src.model.base import BaseModule
 from src.ops import (
-    OpMlaProlog, MLAFlashAttentionInt8, MLASparseFlashAttentionFP16, OpMatmul, OpBatchMatmul,
+    OpMlaProlog, MLAFlashAttention, MLASparseFlashAttention, OpMatmul, OpBatchMatmul,
     OpTransposeBatchMatmul, OpQuantBatchMatmul, OpSwiglu, OpGroupedMatmul,
     Dispatch, Combine, OpAddRmsNorm, OpDynamicQuant, OpMoeGating,
     OpA2ESend, OpA2ERecv, OpE2ARecv, OpLightningIndexer, OpScatterNdUpdate
@@ -39,7 +39,7 @@ class DeepSeekV3DecodeAttn(BaseModule):
 
         self.input_norm = OpAddRmsNorm("input_norm", self.attn_bs, self.config.seq_len, hidden, self.aichip_config)
         self.mla_prolog = OpMlaProlog(self.config)
-        self.page_attention = MLAFlashAttentionInt8(self.config)
+        self.page_attention = MLAFlashAttention(self.config)
         self.bmm_uv_absorb = OpTransposeBatchMatmul("bmm_uv_absorb", heads, bs, self.model_config.kv_lora_rank, self.model_config.v_head_dim, self.aichip_config)
         self.dynamic_quant = OpDynamicQuant("dynamic_quant", bs, v_dim, self.aichip_config)
         self.bmm_o_proj = OpQuantBatchMatmul("bmm_o_proj", bs, v_dim, hidden, self.aichip_config)
@@ -156,7 +156,7 @@ class DeepSeekV32DecodeAttn(DeepSeekV3DecodeAttn):
         # bf16 [bs, 7168] @ [7168, 64] = [bs, 64]
         self.indexer_weights_proj = OpMatmul("indexer_weights_proj_matmul", bs, hidden, self.model_config.index_n_heads, self.aichip_config, elem_size=2)
         self.lightning_indexer = OpLightningIndexer("lightning_indexer", self.config)
-        self.page_attention = MLASparseFlashAttentionFP16(self.config)
+        self.page_attention = MLASparseFlashAttention(self.config)
         self.bmm_uv_absorb = OpTransposeBatchMatmul("bmm_uv_absorb", heads, bs, self.model_config.kv_lora_rank, self.model_config.v_head_dim, self.aichip_config)
         self.dynamic_quant = OpDynamicQuant("dynamic_quant", bs, v_dim, self.aichip_config)
         self.bmm_o_proj = OpQuantBatchMatmul("bmm_o_proj", bs, v_dim, hidden, self.aichip_config)

--- a/src/model/qwen235_decode.py
+++ b/src/model/qwen235_decode.py
@@ -2,7 +2,7 @@ from conf.common import MAX_AVG_RATIO
 from conf.config import Config
 from src.model.base import BaseModule
 from src.ops import (
-    OpQuantBatchMatmul, OpBatchMatmul, OpRotary, GQAFlashAttentionFP16,
+    OpQuantBatchMatmul, OpBatchMatmul, OpRotary, GQAFlashAttention,
     Dispatch, Combine, OpGroupedMatmul, OpSwiglu, OpAddRmsNorm,
     OpDynamicQuant, OpA2ESend, OpA2ERecv, OpE2ARecv
 )
@@ -43,7 +43,7 @@ class Qwen235DecodeAttn(BaseModule):
         self.value_states = OpBatchMatmul("value_states", bs, hidden, kv_heads * head_size, self.aichip_config)
         self.query_rope = OpRotary("query_rope", bs, num_heads, self.config.seq_len, hidden, self.aichip_config)
         self.key_rope = OpRotary("key_rope", bs, kv_heads, self.config.seq_len, hidden, self.aichip_config)
-        self.page_attention = GQAFlashAttentionFP16(self.config)
+        self.page_attention = GQAFlashAttention(self.config)
         self.dynamic_quant = OpDynamicQuant("dynamic_quant", bs, num_heads * head_size, self.aichip_config)
         self.bmm_o_proj = OpQuantBatchMatmul("bmm_o_proj", bs, num_heads * head_size, hidden, self.aichip_config)
         self.post_attention_norm = OpAddRmsNorm("post_norm", self.attn_bs, self.config.seq_len, hidden, self.aichip_config)

--- a/src/ops/__init__.py
+++ b/src/ops/__init__.py
@@ -1,8 +1,9 @@
 from src.ops.base import BaseOp
 from src.ops.matmul import OpMatmul, OpBatchMatmul, OpTransposeBatchMatmul, OpQuantBatchMatmul, OpGroupedMatmul
 from src.ops.page_attention import (
-    MLAFlashAttentionFP16, MLAFlashAttentionInt8,
-    GQAFlashAttentionFP16, MLASparseFlashAttentionFP16
+    MLAFlashAttention,
+    GQAFlashAttention,
+    MLASparseFlashAttention
 )
 from src.ops.swiglu import OpSwiglu
 from src.ops.mla_prolog import OpMlaProlog
@@ -22,10 +23,9 @@ __all__ = [
     "OpTransposeBatchMatmul",
     "OpQuantBatchMatmul",
     "OpGroupedMatmul",
-    "MLAFlashAttentionFP16",
-    "MLAFlashAttentionInt8",
-    "GQAFlashAttentionFP16",
-    "MLASparseFlashAttentionFP16",
+    "MLAFlashAttention",
+    "GQAFlashAttention",
+    "MLASparseFlashAttention",
     "OpSwiglu",
     "OpMlaProlog",
     "Dispatch",

--- a/src/ops/mla_prolog.py
+++ b/src/ops/mla_prolog.py
@@ -90,7 +90,7 @@ class OpMlaProlog(BaseOp):
         weight_dkv = self.model_config.kv_lora_rank * self.model_config.hidden_size
         # tensor W_kr:[d_h^R, h] int8
         weight_kr = self.model_config.qk_rope_head_dim * self.model_config.hidden_size * 2
-        # tensor kv_cache_in:[b, s, dc] int8 [vllm-Ascend bf16]
+        # tensor kv_cache_in:[b, s, dc] int8
         cache_capacity_per_seq = math.ceil(self.model_config.max_kv_length / BLOCK_SIZE)
         block_num = math.ceil(self.config.attn_bs * self.config.seq_len * cache_capacity_per_seq / BLOCK_SIZE)
         kv_cache_in = BLOCK_SIZE * block_num * self.model_config.kv_lora_rank
@@ -117,12 +117,15 @@ class OpMlaProlog(BaseOp):
         # quant_scale_ckv: [d_h^R] float
         quant_scale_ckv = 4 * self.model_config.kv_lora_rank
         # OUTPUT
-        # tensor q_nope:[b, s, n, dc] int8 [vllm-Ascend bf16]
+        # tensor q_nope:[b, s, n, dc] int8
         q_nope = self.config.attn_bs * self.config.seq_len * self.model_config.num_attention_heads * self.model_config.kv_lora_rank
         # tensor q_rope:[b, s, n, d_h^R] bf16
         q_rope = 2 * self.config.attn_bs * self.config.seq_len * self.model_config.num_attention_heads * self.model_config.qk_rope_head_dim
         # tensor dequant_scale_q_nope: [b*s, n, 1] float
         dequant_scale_q_nope = 4 * self.config.attn_bs * self.config.seq_len * self.model_config.num_attention_heads
+        if self.config.kv_cache_quant == "bf16":
+            q_nope = q_nope * 2
+            kv_cache_in = kv_cache_in * 2
         self.total_data_movement = (
             x + weight_dq + weight_uq + weight_uk + weight_qr + weight_dkv + weight_kr + kv_cache_in + kr_cache_in +
             rmsnorm_gamma_cq + rmsnorm_gamma_ckv + rope_sin + rope_cos + cache_index + dequant_scale_x + dequant_scale_w_dq +

--- a/src/ops/page_attention.py
+++ b/src/ops/page_attention.py
@@ -4,104 +4,56 @@ from conf.common import US_2_SEC
 import math
 
 
-class MLAFlashAttentionFP16(BaseOp):
+class MLAFlashAttention(BaseOp):
     '''
     Description:
-        The Flash Attention operation for the model used MLA attention mechanism in FP16 precision.
-    Attributes:
-        config: The configuration of the search task.
-    '''
-    def __init__(self, config, elem_size=2):
-        self.op_disc_factor()
-        super().__init__("MLAFlashAttentionFP16", config.aichip_config, elem_size)
-        self.model_config = config.model_config
-        self.attn_bs = config.attn_bs
-        self.kv_len = config.kv_len
-
-    def compute_cost(self):
-        self.qk_flops = (
-            2 * self.attn_bs * self.model_config.num_attention_heads * 
-            self.kv_len * (2 * self.model_config.kv_lora_rank + self.model_config.qk_rope_head_dim)
-        )
-        self.softmax_flops =(
-            5 * self.attn_bs * self.model_config.num_attention_heads * self.kv_len
-        )
-        # matrix absorption
-        self.uv_absorb_flops =(
-            2 * self.attn_bs * self.model_config.kv_lora_rank * 
-            self.model_config.num_attention_heads * self.model_config.v_head_dim
-        )
-        self.compute_time = (
-            self.qk_flops / self.cube_flops +
-            self.softmax_flops / self.vec_flops +
-            self.uv_absorb_flops / self.cube_flops
-        )
-        return self.compute_time
-
-    def memory_cost(self):
-        # q_block: [B, n/tp, S, (512+64)] fp16
-        q_block = 2 * self.attn_bs * self.model_config.num_attention_heads * self.seq_len * (self.model_config.kv_lora_rank + self.model_config.qk_rope_head_dim)
-        # kv_nope_block: [B, 1, KV, 512] fp16
-        kv_nope_block = 2 * self.attn_bs * self.kv_len * self.model_config.kv_lora_rank
-        # kv_rope_block: [B, 1, KV, 64] fp16
-        kv_rope_block = 2 * self.attn_bs * self.kv_len * self.model_config.qk_rope_head_dim
-        # o_block: [B, n/tp, S, 512] fp16
-        o_block = 2 * self.attn_bs * self.model_config.num_attention_heads * self.seq_len * self.model_config.kv_lora_rank
-
-        self.bytes = q_block + kv_nope_block + kv_rope_block + o_block
-        self.memory_time = self.bytes / self.local_memory_bandwidth
-        return self.memory_time
-
-
-class MLAFlashAttentionInt8(BaseOp):
-    '''
-    Description:
-        The Flash Attention operation for the model used MLA attention mechanism in INT8 precision.
+        The Flash Attention operation for the model used MLA attention mechanism.
     Attributes:
         config: The configuration of the search task.
     '''
     def __init__(self, config, elem_size=1):
+        self.config = config
         self.model_config = config.model_config
         self.attn_bs = config.attn_bs
         self.kv_len = config.kv_len
         self.seq_len = config.seq_len
         self.static_cost = 30 * US_2_SEC
-        super().__init__("MLAFlashAttentionInt8", config.aichip_config, elem_size, static_cost=self.static_cost)
+        super().__init__("MLAFlashAttention", config.aichip_config, elem_size, static_cost=self.static_cost)
         self.memory_ratio = 0.8
 
     def compute_cost(self):
-        # qk_position = 2*B*128/TP*S*64*KV
+        # qk_position = 2*B*N/TP*S*Dr*KV
         # BF16, cube core
-        # - q_rope = [B, 128/TP, S, 64]
-        # - k_rope = [B, 128/TP, KV, 64] (trans) [B, 128/TP, 64, KV]
-        # - output_qk_rope = [B, 128/TP, S, KV]
+        # - q_rope = [B, N/TP, S, Dr]
+        # - k_rope = [B, N/TP, KV, Dr] (trans) [B, N/TP, Dr, KV]
+        # - output_qk_rope = [B, N/TP, S, KV]
         qk_rope = (
             2 * self.attn_bs * self.model_config.num_attention_heads *
             self.seq_len * self.model_config.qk_rope_head_dim * self.kv_len
         )
-        # qk_matmul = 2*B*128/TP*S*512*KV
-        # INT8, cube core
-        # - q_nope = [B, 128/TP, S, 512]
-        # - k_nope = [B, 128/TP, KV, 512] (trans) [B, 128/TP, 512, KV]
-        # - output_qk_nope = [B, 128/TP, S, KV]
+        # qk_matmul = 2*B*N/TP*S*D*KV
+        # INT8 for kv_cache_quant is int8; BF16 for kv_cache_quant is bf16, cube core
+        # - q_nope = [B, N/TP, S, D]
+        # - k_nope = [B, N/TP, KV, D] (trans) [B, N/TP, D, KV]
+        # - output_qk_nope = [B, N/TP, S, KV]
         qk_matmul =(
             2 * self.attn_bs * self.model_config.num_attention_heads *
             self.seq_len * self.model_config.kv_lora_rank * self.kv_len
         )
-        # (output_qk + output_qkv) -> softmax = 5*[B, 128/TP, S, KV]
+        # (output_qk + output_qkv) -> softmax = 5*[B, N/TP, S, KV]
         # BF16, vector core
-        # - output_qk = [B, 128/TP, S, KV]
-        # - output_qk = [B, 128/TP, S, KV]
-        # - output_softmax = [B, 128/TP, S, KV]
+        # - output_qk = [B, N/TP, S, KV]
+        # - output_qk = [B, N/TP, S, KV]
+        # - output_softmax = [B, N/TP, S, KV]
         softmax =(
             5 * self.attn_bs * self.model_config.num_attention_heads *
             self.seq_len * self.kv_len
         )
-        # qkv_matmul = 2*B*128/TP*S*KV*512
-        # INT8, cube core
-        # - output_softmax = [B, 128/TP, S, KV]
-        # - v_nope = [B, 128/TP, KV, 512]
-        # - output_matmul = [B, 128/TP, S, 512]
+        # qkv_matmul = 2*B*N/TP*S*KV*D
+        # INT8 for kv_cache_quant is int8; BF16 for kv_cache_quant is bf16, cube core
+        # - output_softmax = [B, N/TP, S, KV]
+        # - v_nope = [B, N/TP, KV, D]
+        # - output_matmul = [B, N/TP, S, D]
         sv_matmul =(
             2 * self.attn_bs * self.model_config.num_attention_heads *
             self.seq_len * self.kv_len * self.model_config.kv_lora_rank
@@ -109,39 +61,44 @@ class MLAFlashAttentionInt8(BaseOp):
 
         self.total_computation = qk_rope + qk_matmul + softmax + sv_matmul
         qk_rope_time = qk_rope / self.cube_flops_fp16
-        qk_matmul_time = qk_matmul / self.cube_flops_int8
+        if self.config.kv_cache_quant == "bf16":
+            qk_matmul_time = qk_matmul / self.cube_flops_fp16
+            sv_matmul_time = sv_matmul / self.cube_flops_fp16
+        else:
+            qk_matmul_time = qk_matmul / self.cube_flops_int8
+            sv_matmul_time = sv_matmul / self.cube_flops_int8
         softmax_time = softmax / self.vec_flops_fp16
-        sv_matmul_time = sv_matmul / self.cube_flops_int8
         self.compute_time = qk_rope_time + qk_matmul_time + softmax_time + sv_matmul_time
         return self.compute_time
 
     def memory_cost(self):
-        # q_nope_block: [B, S, n/tp, 512] INT8
+        # q_nope_block: [B, S, n/tp, D]
+        # INT8 for kv_cache_quant is int8; BF16 for kv_cache_quant is bf16
         q_nope_block = self.attn_bs * self.seq_len * self.model_config.num_attention_heads * self.model_config.kv_lora_rank
-        # q_rope_block: [B, S, n/tp, 64] BF16
+        # q_rope_block: [B, S, n/tp, Dr] BF16
         q_rope_block = 2 * self.attn_bs * self.seq_len * self.model_config.num_attention_heads * self.model_config.qk_rope_head_dim
-        # kv_nope_block: [block_num, 1, block_size, 512] INT8
+        # kv_nope_block: [block_num, 1, block_size, D] INT8
+        # INT8 for kv_cache_quant is int8; BF16 for kv_cache_quant is bf16
         # key_nope and value_nope are loaded separately
         block_num = math.ceil(self.attn_bs * self.kv_len / BLOCK_SIZE)
-        # int8
         kv_nope_block = 2 * block_num * BLOCK_SIZE * self.model_config.kv_lora_rank
-        # bf16 [vllm-ascend only support bf16]
-        # kv_nope_block = 4 * block_num * BLOCK_SIZE * self.model_config.kv_lora_rank
-        # kv_rope_block: [block_num, 1, n/tp, 64] BF16
-        # key_rope and value_rope are loaded separately
-        kv_rope_block = 4 * block_num * BLOCK_SIZE * self.model_config.qk_rope_head_dim
-        # o_block: [B, S, n/tp, 512] BF16
+        # k_rope_block: [block_num, 1, n/tp, Dr] BF16
+        k_rope_block = 2 * block_num * BLOCK_SIZE * self.model_config.qk_rope_head_dim
+        # o_block: [B, S, n/tp, D] BF16
         o_block = 2 * self.attn_bs * self.seq_len * self.model_config.num_attention_heads * self.model_config.kv_lora_rank
+        if self.config.kv_cache_quant == "bf16":
+            q_nope_block = q_nope_block * 2
+            kv_nope_block = kv_nope_block * 2
 
-        self.total_data_movement = q_nope_block + q_rope_block + kv_nope_block + kv_rope_block + o_block
+        self.total_data_movement = q_nope_block + q_rope_block + kv_nope_block + k_rope_block + o_block
         self.memory_time = self.total_data_movement / self.local_memory_bandwidth / self.memory_ratio
         return self.memory_time
 
 
-class MLASparseFlashAttentionFP16(BaseOp):
+class MLASparseFlashAttention(BaseOp):
     '''
     Description:
-        Sparse Flash Attention for MLA models in FP16 precision.
+        Sparse Flash Attention for MLA models.
 
         - query: [B, S, N1, D+rope_head_dim] (nope + rope parts)
         - key/value: stored in paged KV cache, accessed via sparse_indices + block_table
@@ -152,80 +109,92 @@ class MLASparseFlashAttentionFP16(BaseOp):
         config: The configuration of the search task.
     '''
     def __init__(self, config, elem_size=2):
-        super().__init__("MLASparseFlashAttentionFP16", config.aichip_config, elem_size, static_cost=70*US_2_SEC)
+        self.config = config
+        super().__init__("MLASparseFlashAttention", config.aichip_config, elem_size, static_cost=70*US_2_SEC)
         self.model_config = config.model_config
         self.attn_bs = config.attn_bs
         self.kv_len = config.kv_len
         self.seq_len = config.seq_len
 
     def compute_cost(self):
-        # qk_position = 2 * b * s * n * sparse_count * (512+64)
-        # BF16, cube core
-        # q = [b, s, n, (512+64)]
-        # k = [b, sparse_count, n, (512+64)]
-        qk_flops = (
+        # qk_position = 2 * B * S * N1 * sparse_count * Dr
+        # q = [B, S, N1, Dr]
+        # k = [B, sparse_count, N1, Dr]
+        qk_rope = (
             2 * self.attn_bs * self.seq_len * self.model_config.num_attention_heads *
-            SPARSE_COUNT * (self.model_config.kv_lora_rank + self.model_config.qk_rope_head_dim)
+            SPARSE_COUNT * self.model_config.qk_rope_head_dim
+        )
+        # qk_matmul = 2 * B * S * N1 * sparse_count * D
+        # q = [B, S, N1, D]
+        # k = [B, sparse_count, N1, D]
+        qk_matmul = (
+            2 * self.attn_bs * self.seq_len * self.model_config.num_attention_heads *
+            SPARSE_COUNT * self.model_config.kv_lora_rank
         )
         # softmax: 5 * B * N1 * S * sparse_count
-        softmax_flops = (
+        softmax = (
             5 * self.attn_bs * self.model_config.num_attention_heads * self.seq_len * SPARSE_COUNT
         )
         # qkv_matmul (sv): 2 * B * N1 * S * D * sparse_count
-        # BF16, cube core
-        # - output_softmax = [B, 128/TP, S, sparse_count]
-        # - v_nope = [B, 128/TP, sparse_count, 512]
-        # - output_matmul = [B, 128/TP, S, 512]
-        sv_flops = (
+        # - output_softmax = [B, N1/TP, S, sparse_count]
+        # - v_nope = [B, N1/TP, sparse_count, 512]
+        # - output_matmul = [B, N1/TP, S, 512]
+        sv_matmul = (
             2 * self.attn_bs * self.model_config.num_attention_heads *
             self.seq_len * self.model_config.kv_lora_rank * SPARSE_COUNT
         )
-        self.total_computation = qk_flops + softmax_flops + sv_flops
-        self.compute_time = (
-            qk_flops / self.cube_flops_fp16 +
-            softmax_flops / self.vec_flops_fp16 +
-            sv_flops / self.cube_flops_fp16
-        )
+        self.total_computation = qk_rope + qk_matmul + softmax + sv_matmul
+        qk_rope_time = qk_rope / self.cube_flops_fp16
+        if self.config.kv_cache_quant == "bf16":
+            qk_matmul_time = qk_matmul / self.cube_flops_fp16
+            sv_matmul_time = sv_matmul / self.cube_flops_fp16
+        else:
+            qk_matmul_time = qk_matmul / self.cube_flops_int8
+            sv_matmul_time = sv_matmul / self.cube_flops_int8
+        softmax_time = softmax / self.vec_flops_fp16
+        self.compute_time = qk_rope_time + qk_matmul_time + softmax_time + sv_matmul_time
         return self.compute_time
 
     def memory_cost(self):
-        # q_block: [B, N1, S, D+R] bf16
-        q_bytes = self.elem_size * self.attn_bs * self.model_config.num_attention_heads * self.seq_len * (self.model_config.kv_lora_rank + self.model_config.qk_rope_head_dim)
+        # q_nope_block: [B, S, N1/tp, D]
+        # INT8 for kv_cache_quant is int8; BF16 for kv_cache_quant is bf16
+        q_nope_block = self.attn_bs * self.model_config.num_attention_heads * self.seq_len * self.model_config.kv_lora_rank
+        # q_rope_block: [B, S, N1/tp, Dr] BF16
+        q_rope_block = 2 * self.attn_bs * self.model_config.num_attention_heads * self.seq_len * self.model_config.qk_rope_head_dim
         # kv_block: only selected blocks, key+value bf16, N2=1 for MLA
-        # key(D+R) + value(D)
-        k_bytes = self.elem_size * self.attn_bs * SPARSE_COUNT * (self.model_config.kv_lora_rank + self.model_config.qk_rope_head_dim)
-        v_bytes = self.elem_size * self.attn_bs * SPARSE_COUNT * self.model_config.kv_lora_rank
+        kv_nope_block = 2 * self.attn_bs * SPARSE_COUNT * self.model_config.kv_lora_rank
+        k_rope_block = 2 * self.attn_bs * SPARSE_COUNT * self.model_config.qk_rope_head_dim
         # sparse_indices: [B, S, SPARSE_COUNT] int32
         sparse_idx_bytes = self.attn_bs * self.seq_len * SPARSE_COUNT * 4
         # block_table: [b, kv_len/block_size] int32
         block_table_bytes = self.attn_bs * self.kv_len / BLOCK_SIZE * 4
         # o_block: [B, N1, S, D] bf16
-        o_bytes = self.elem_size * self.attn_bs * self.model_config.num_attention_heads * self.seq_len * self.model_config.kv_lora_rank
+        o_block = 2 * self.attn_bs * self.model_config.num_attention_heads * self.seq_len * self.model_config.kv_lora_rank
         # softmaxMaxOut+softmaxSumOut: [B, N2, S1, N1/N2] FLOAT
         softmax_out_bytes = 2 * 4 * self.attn_bs * self.seq_len * self.model_config.num_attention_heads
+        if self.config.kv_cache_quant == "bf16":
+            q_nope_block = q_nope_block * 2
+            kv_nope_block = kv_nope_block * 2
 
-        self.total_data_movement = q_bytes + k_bytes + v_bytes + o_bytes + sparse_idx_bytes + block_table_bytes + softmax_out_bytes
+        self.total_data_movement = q_nope_block + q_rope_block + kv_nope_block + k_rope_block + o_block + sparse_idx_bytes + block_table_bytes + softmax_out_bytes
         self.memory_time = self.total_data_movement / self.local_memory_bandwidth
         return self.memory_time
 
 
-class GQAFlashAttentionFP16(BaseOp):
+class GQAFlashAttention(BaseOp):
     '''
     Description:
-        The Flash Attention operation for the model used GQA attention mechanism in FP16 precision.
+        The Flash Attention operation for the model used GQA attention mechanism.
     Attributes:
         config: The configuration of the search task.
     '''
     def __init__(self, config, elem_size=2):
-        self.op_compute_disc()
-        super().__init__("FlashAttentionFP16", config.aichip_config, elem_size)
+        self.config = config
+        super().__init__("GQAFlashAttention", config.aichip_config, elem_size)
         self.model_config = config.model_config
         self.attn_bs = config.attn_bs
         self.kv_len = config.kv_len
         self.seq_len = config.seq_len
-
-    def op_compute_disc(self):
-        return 0.651
 
     def compute_cost(self):
         # qk_matmul: 2*B*n*s*D*kv
@@ -256,21 +225,25 @@ class GQAFlashAttentionFP16(BaseOp):
             self.model_config.head_size *
             self.kv_len
         )
-        cube_time = (qk_matmul + qkv_matmul) / self.cube_flops_fp16
+        self.total_computation = qk_matmul + softmax + qkv_matmul
+        if self.config.kv_cache_quant == "bf16":
+            cube_time = (qk_matmul + qkv_matmul) / self.cube_flops_fp16
+        else:
+            cube_time = (qk_matmul + qkv_matmul) / self.cube_flops_int8
         vec_time = softmax / self.vec_flops_fp16
         self.compute_time = cube_time + vec_time
         return self.compute_time
 
     def memory_cost(self):
         # q_block: [B, n, s, D]
-        # kv_cache: [B, n_kv, kv, D]
+        q_block = self.attn_bs * self.model_config.num_heads * self.seq_len * self.model_config.head_size
+        # kv_cache: [B, n_kv, kv, D](key+value loaded separately)
+        kv_block = 2 * self.attn_bs * self.model_config.kv_heads * self.kv_len * self.model_config.head_size
         # o_block: [B, n, s, D]
-        self.bytes = (
-            2 * self.elem_size *
-            self.attn_bs *
-            self.model_config.kv_heads *
-            self.kv_len *
-            self.model_config.head_size
-        )
-        self.memory_time = self.bytes / self.local_memory_bandwidth
+        o_block = self.attn_bs * self.model_config.num_heads * self.seq_len * self.model_config.head_size
+
+        if self.config.kv_cache_quant == "bf16":
+            kv_block = kv_block * 2
+        self.total_data_movement = q_block + kv_block + o_block
+        self.memory_time = self.total_data_movement / self.local_memory_bandwidth
         return self.memory_time

--- a/src/search/base.py
+++ b/src/search/base.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 from abc import ABC, abstractmethod
-from conf.common import BYTE_2_GB, DTYPE_BF16
+from conf.common import BYTE_2_GB, DTYPE_INT8, DTYPE_BF16
 from conf.model_config import ModelConfig
 from conf.config import Config
 
@@ -40,7 +40,8 @@ class BaseSearch(ABC):
         kv_size = (
             attn_bs * self.config.kv_len * 
             (model_config.kv_lora_rank + model_config.qk_rope_head_dim) * 
-            model_config.num_layers * BYTE_2_GB * DTYPE_BF16
+            model_config.num_layers * BYTE_2_GB * 
+            (DTYPE_INT8 if self.config.kv_cache_quant == "int8" else DTYPE_BF16)
         )
 
         # Attention Static Memory
@@ -134,7 +135,8 @@ class BaseSearch(ABC):
             attn_bs * self.config.kv_len * 
             model_config.kv_heads * 
             model_config.head_size * 
-            model_config.num_layers * BYTE_2_GB * DTYPE_BF16
+            model_config.num_layers * BYTE_2_GB *
+            (DTYPE_INT8 if self.config.kv_cache_quant == "int8" else DTYPE_BF16)
         )
 
         # Attention Static Memory

--- a/src/search/deepep.py
+++ b/src/search/deepep.py
@@ -29,7 +29,7 @@ class DeepEpSearch(BaseSearch):
         super().__init__(config)
         self.perf_deepep_results = []
 
-    def _evaluate_config(self, attn_bs, temp_config, routed_expert_per_die):
+    def _evaluate_config(self, attn_bs, routed_expert_per_die):
         """Evaluate a single (attn_bs) configuration.
 
         Runs the model and computes timing, memory, and e2e_time.
@@ -46,10 +46,10 @@ class DeepEpSearch(BaseSearch):
                 self.config.model_config, attn_bs
             )
         ffn_bs = attn_bs * self.config.model_config.num_experts_per_tok
-        temp_config.attn_bs = attn_bs
-        temp_config.ffn_bs = ffn_bs
+        self.config.attn_bs = attn_bs
+        self.config.ffn_bs = ffn_bs
 
-        model = get_model(temp_config)
+        model = get_model(self.config)
         attn = model["attn"]
         attn()
         moe = model["moe"]
@@ -105,22 +105,16 @@ class DeepEpSearch(BaseSearch):
             'used_memory': used_memory,
         }
 
-    def _run_homogeneous_deepep(self, device_type_str: str, min_die: int, max_die: int, die_step: int) -> dict:
+    def _run_homogeneous_deepep(self, min_die: int, max_die: int, die_step: int) -> dict:
         '''
         Run homogeneous DeepEP on a single device type.
 
         Args:
-            device_type_str: Device type string (e.g., "Ascend_A3Pod")
             min_die, max_die, die_step: Die search range
 
         Returns:
             Dictionary mapping total_die -> throughput
         '''
-        from conf.hardware_config import DeviceType, HWConf
-
-        device_type = DeviceType(device_type_str)
-        aichip_config = HWConf.create(device_type)
-
         results = {}
 
         for total_die in range(min_die, max_die + 1, die_step):
@@ -129,41 +123,20 @@ class DeepEpSearch(BaseSearch):
                 self.config.model_config.n_shared_experts,
                 total_die
             )
-            attn_bs_min, attn_bs_max = self.config.min_attn_bs, self.config.max_attn_bs
-
-            # Create a temporary config with the device type
-            temp_config = Config(
-                serving_mode="DeepEP",
-                model_type=self.config.model_type.value,
-                device_type=device_type_str,
-                min_attn_bs=self.config.min_attn_bs,
-                max_attn_bs=self.config.max_attn_bs,
-                min_die=min_die,
-                max_die=max_die,
-                die_step=die_step,
-                tpot=self.config.tpot,
-                kv_len=self.config.kv_len,
-                micro_batch_num=1,
-                next_n=self.config.seq_len - 1,
-                multi_token_ratio=self.config.multi_token_ratio,
-                attn_tensor_parallel=self.config.attn_tensor_parallel,
-                ffn_tensor_parallel=self.config.ffn_tensor_parallel,
-                deployment_mode="Homogeneous"
-            )
-            temp_config.attn_die = total_die
-            temp_config.ffn_die = total_die
-            temp_config.routed_expert_per_die = routed_expert_per_die
+            self.config.attn_die = total_die
+            self.config.ffn_die = total_die
+            self.config.routed_expert_per_die = routed_expert_per_die
 
             # Sweep all attn_bs from min to max, pick the one with best throughput
             best_attn_bs = None
             best_r = None
             best_throughput = -1
 
-            for attn_bs in range(attn_bs_min, attn_bs_max + 1):
-                r = self._evaluate_config(attn_bs, temp_config, routed_expert_per_die)
+            for attn_bs in range(self.config.min_attn_bs, self.config.max_attn_bs + 1):
+                r = self._evaluate_config(attn_bs, routed_expert_per_die)
 
                 if (r['e2e_time'] > self.config.tpot or
-                    r['used_memory'] > aichip_config.aichip_memory * BYTE_2_GB * MEMORY_THRESHOLD_RATIO):
+                    r['used_memory'] > self.config.aichip_config.aichip_memory * BYTE_2_GB * MEMORY_THRESHOLD_RATIO):
                     continue
 
                 throughput = attn_bs / r['e2e_time'] / MS_2_SEC
@@ -177,7 +150,7 @@ class DeepEpSearch(BaseSearch):
 
             best_r['attn_bs'] = best_attn_bs
             best_r['throughput'] = best_throughput
-            best_r['available_memory'] = aichip_config.aichip_memory * BYTE_2_GB * MEMORY_THRESHOLD_RATIO - best_r['used_memory']
+            best_r['available_memory'] = self.config.aichip_config.aichip_memory * BYTE_2_GB * MEMORY_THRESHOLD_RATIO - best_r['used_memory']
 
             results[total_die] = best_r
 
@@ -198,23 +171,31 @@ class DeepEpSearch(BaseSearch):
         logging.info("This is for comparison purposes only, NOT a truly heterogeneous deployment.")
         logging.info("=" * 60)
 
+        # Save original device config
+        orig_device_type = self.config.device_type
+        orig_aichip_config = self.config.aichip_config
+
         # Run DeepEP on device_type1 (attention device)
         logging.info(f"Running DeepEP on {self.config.device_type.value} (device_type1)...")
         results_device1 = self._run_homogeneous_deepep(
-            self.config.device_type.value,
             self.config.min_die,
             self.config.max_die,
             self.config.die_step
         )
 
-        # Run DeepEP on device_type2 (FFN device)
-        logging.info(f"Running DeepEP on {self.config.device_type2.value} (device_type2)...")
+        # Swap to device_type2 (FFN device)
+        self.config.device_type = self.config.device_type2
+        self.config.aichip_config = self.config.aichip_config2
+        logging.info(f"Running DeepEP on {self.config.device_type.value} (device_type2)...")
         results_device2 = self._run_homogeneous_deepep(
-            self.config.device_type2.value,
             self.config.min_die2,
             self.config.max_die2,
             self.config.die_step2
         )
+
+        # Restore original device config
+        self.config.device_type = orig_device_type
+        self.config.aichip_config = orig_aichip_config
 
         # Combine results with weighted average throughput
         for die1, r1 in results_device1.items():
@@ -262,7 +243,6 @@ class DeepEpSearch(BaseSearch):
             Search the optimal attention batch size for the model used DeepEP serving.
         '''
         results = self._run_homogeneous_deepep(
-            self.config.device_type.value,
             self.config.min_die,
             self.config.max_die,
             self.config.die_step

--- a/tests/unit/test_config_hardware.py
+++ b/tests/unit/test_config_hardware.py
@@ -136,3 +136,53 @@ def test_heterogeneous_requires_device_type2() -> None:
             ffn_tensor_parallel=1,
             deployment_mode="Heterogeneous",
         )
+
+
+@pytest.mark.unit
+def test_config_kv_cache_quant_default() -> None:
+    """Default kv_cache_quant should be bf16."""
+    cfg = Config(
+        serving_mode="AFD",
+        model_type=ModelType.DEEPSEEK_V3.value,
+        device_type=DeviceType.NvidiaH100SXM.value,
+        min_attn_bs=2, max_attn_bs=32,
+        min_die=16, max_die=16, die_step=16,
+        tpot=200, kv_len=2048,
+        micro_batch_num=2, next_n=1, multi_token_ratio=0.7,
+        attn_tensor_parallel=1, ffn_tensor_parallel=1,
+    )
+    assert cfg.kv_cache_quant == "bf16"
+
+
+@pytest.mark.unit
+def test_config_kv_cache_quant_int8() -> None:
+    """kv_cache_quant=int8 should be accepted."""
+    cfg = Config(
+        serving_mode="AFD",
+        model_type=ModelType.DEEPSEEK_V3.value,
+        device_type=DeviceType.NvidiaH100SXM.value,
+        min_attn_bs=2, max_attn_bs=32,
+        min_die=16, max_die=16, die_step=16,
+        tpot=200, kv_len=2048,
+        micro_batch_num=2, next_n=1, multi_token_ratio=0.7,
+        attn_tensor_parallel=1, ffn_tensor_parallel=1,
+        kv_cache_quant="int8",
+    )
+    assert cfg.kv_cache_quant == "int8"
+
+
+@pytest.mark.unit
+def test_config_kv_cache_quant_invalid_raises() -> None:
+    """Invalid kv_cache_quant should raise ValueError."""
+    with pytest.raises(ValueError, match="Invalid kv_cache_quant"):
+        Config(
+            serving_mode="AFD",
+            model_type=ModelType.DEEPSEEK_V3.value,
+            device_type=DeviceType.NvidiaH100SXM.value,
+            min_attn_bs=2, max_attn_bs=32,
+            min_die=16, max_die=16, die_step=16,
+            tpot=200, kv_len=2048,
+            micro_batch_num=2, next_n=1, multi_token_ratio=0.7,
+            attn_tensor_parallel=1, ffn_tensor_parallel=1,
+            kv_cache_quant="fp32",
+        )

--- a/webapp/backend/main.py
+++ b/webapp/backend/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, BackgroundTasks, HTTPException, APIRouter
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from uuid import uuid4
 import pandas as pd
 import subprocess
@@ -55,6 +55,15 @@ class RunRequest(BaseModel):
     min_die2: Optional[int] = None
     max_die2: Optional[int] = None
     die_step2: Optional[int] = None
+    kv_cache_quant: str = "bf16"
+
+    @field_validator("kv_cache_quant")
+    @classmethod
+    def validate_kv_cache_quant(cls, v: str) -> str:
+        valid = ("bf16", "int8")
+        if v not in valid:
+            raise ValueError(f"kv_cache_quant must be one of {valid}, got '{v}'")
+        return v
 
 
 def _sanitize_args(req: RunRequest) -> List[str]:
@@ -71,6 +80,7 @@ def _sanitize_args(req: RunRequest) -> List[str]:
         "--multi_token_ratio", str(req.multi_token_ratio),
         "--attn_tensor_parallel", str(req.attn_tensor_parallel),
         "--ffn_tensor_parallel", str(req.ffn_tensor_parallel),
+        "--kv_cache_quant", req.kv_cache_quant,
         "--deployment_mode", req.deployment_mode,
     ]
     if req.die_step is not None:

--- a/webapp/frontend/components/RunExperimentTab/RunForm.vue
+++ b/webapp/frontend/components/RunExperimentTab/RunForm.vue
@@ -126,6 +126,13 @@
           <input type="number" v-model.number="form.ffn_tensor_parallel" min="1" />
         </div>
       </div>
+      <div class="field">
+        <label>KV Cache Quantization</label>
+        <select v-model="form.kv_cache_quant">
+          <option value="bf16">BF16</option>
+          <option value="int8">INT8</option>
+        </select>
+      </div>
     </details>
 
     <div v-if="error" class="error-message">
@@ -182,7 +189,8 @@ export default {
       next_n: 1,
       multi_token_ratio: 0.7,
       attn_tensor_parallel: 1,
-      ffn_tensor_parallel: 1
+      ffn_tensor_parallel: 1,
+      kv_cache_quant: 'bf16'
     });
 
     const tpotInput = ref('50');


### PR DESCRIPTION
Add KV Cache quantization switch supporting bf16 and int8 precision
Changes:
  - Add kv_cache_quant parameter to Config with bf16/int8 validation
  - Add --kv_cache_quant CLI argument (default: bf16)
  - Add kv_cache_quant selector to web UI Advanced section
  - Refactor attention ops (MLAFlashAttention, MLASparseFlashAttention, GQAFlashAttention) to internally dispatch on quantization mode instead of maintaining separate fp16/int8 class variants
  - Update KV cache memory calculation in BaseSearch to use the configured dtype
  - Remove temporary Config creation in DeepEpSearch, aligning with AFD's pattern of mutating self.config directly
  - Add unit tests for default, valid int8, and invalid value
<img width="900" height="358" alt="image" src="https://github.com/user-attachments/assets/43ce83d9-a288-4d87-9925-0a703709ceef" />
